### PR TITLE
migrate to nuxeo 6.0 (do not require jQuery as it is now served by richf...

### DIFF
--- a/src/main/resources/OSGI-INF/theme-override.xml
+++ b/src/main/resources/OSGI-INF/theme-override.xml
@@ -24,11 +24,9 @@
     <resource name="jquery.terminal.js">
       <!-- <path>scripts/shell/jquery.terminal-0.6.3.js</path> -->
       <path>scripts/shell/jquery.terminal-0.7.6.js</path>
-      <require>jquery.js</require>
     </resource>
     <resource name="nuxeo-automation.js">
       <path>scripts/nuxeo-automation.js</path>
-      <require>jquery.js</require>
     </resource>
     <resource name="nxshell.js">
       <path>scripts/shell/nxshell.js</path>


### PR DESCRIPTION
...aces/jsf2)

This breaks the ajax nav in admin center because of messed up jQuery resources.
